### PR TITLE
dummy class for DE mimicking EN, setting flag defaults to false

### DIFF
--- a/code/languages/de.py
+++ b/code/languages/de.py
@@ -1,0 +1,4 @@
+from languages.en import En
+
+class De(En):
+    pass

--- a/code/utils/config.py
+++ b/code/utils/config.py
@@ -14,8 +14,8 @@ class Config:
     clean_dialogs = True  # if True, run preprocessing on dialogs
     languages = ['pt']
     download = False
-    pre_filter = True
-    extract = True
-    post_filter = True
-    create_dataset = True
+    pre_filter = False
+    extract = False
+    post_filter = False
+    create_dataset = False
     directory = os.path.join('data', 'filtered')


### PR DESCRIPTION
eloszor meg egy-ket javaslat az interface-szel kapcsolatban:

szerintem inkabb kevesebb default legyen es tobb kotelezo argumentum.

ha a flagek store_true-val vannak, akkor nem lehet oket kikapcsolni, csak be, nem?
akkor viszont a default (config.py)-beliek legyenek mind False-ok. Szerintem ez igy intuitiv is, azok a lepesek lesznek, amiket megad a user. 

szerintem legyen egy -a kapcsolo arra, hogy "minden", az viszont nem jo, hogy ha az osszes flag hianyzik akkor az azt jelenti, hogy az osszes "igen", ez mindenfajta programmartikus hasznalatot megnehezit + varatlan is.

szerintem ha letezik barmilyen fajl, amit egy lepesnek, pl. pre-filter, irnia kene, pl. az author_and_title, akkor mar az elejen faileljen el a lepes. Most az van, hogy ha lefuttatom a pre-filtert, aztan rajovok, hogy valamit modositanom kell az elozo lepesben, pl. nem volt minden letoltve, es utana ujrafuttatom, akkor szep csendben vegigfut a prefilter de aztan elveszitem az author_and_title infot, mert nem fogja kiirni, mert letezik a fajl. Ilyenkor inkabb az elejen alljon le es szoljon, hogy torold vagy vidd onnan a fajlt.


nemet keziszures:

az author_and_title.txt kezi szuresenek az elso es legproduktivabb lepese nalam az volt, hogy eloszor is hagytam vegigfutni a pipelinet a teljes listaval es utana joinoltam a vegeredmenyt a konzvek listajaval, hogy mar csak azokat kelljen kezzel atnezni, amibol tenyleg vennenk ki dialogusokat. Gondold majd at, hogy nem akarod-e ezt a lepest supportalni a kodban, en most az alabbi parancsokkal csinaltam (vigyazz, ne csak copy-paste-eld, mert literal TAB-ok vannak benne). Sokat segitene, ha a :: elvalasztas helyett tab-szeparalt fajlokat irnal/olvasnal, az egy jol bevett sztenderd formatum.

```
cp author_and_title.txt author_and_title.orig.txt
cat author_and_title.txt | sed 's/^\(.*\) :: \(.*\) :: \(.*\)$/\3  \1      \2/' | sort > author_and_title.tsv
cat dialogs.txt | grep -o '^[0-9]*' | sort -u | join -t '       ' - author_and_title.tsv > author_and_title_filtered.tsv
cat author_and_title_filtered.tsv | sed 's/^\(.*\)      \(.*\)  \(.*\)/\2 :: \3 :: \1/' | sort > author_and_title.txt

wc -l author_and_title*.txt
1579 author_and_title.orig.txt
  93 author_and_title.txt
```

Ebbol kezzel toroltem 13 sort, ami egyertelmuen filozofiai iras vagy szakirodalom, ilyesmi, utana 
pedig:
python code/main.py -l de -e -f2 -c
(miutan a configban minden flag defaultjat False-ra allitottam)

Vegul, ugy latom, csak par szaz sorral lett ettol kevesebb a vegeredmeny, de hat ez is volt varhato...

Az osszes output itt van nessien:
`/home/recski/projects/gutenberg-dialog/data/filtered/de`

es osszehasonlitaskepp elraktam a kezi szures elotti kimenetet ide:
`/home/recski/projects/gutenberg-dialog/data/filtered/de/full_20200423`
